### PR TITLE
Changing prefix2 to be C-b instead of C-a

### DIFF
--- a/dotfiles/.tmux.conf
+++ b/dotfiles/.tmux.conf
@@ -3,9 +3,9 @@
 #
 
 
-# Set the prefix keys.  Keep the legacy Ctrl-A for screens people, but I prefer the single key `
+# Set the prefix keys.  Keep the legacy Ctrl-B for screens people, but I prefer the single key `
 set -g prefix `
-set -g prefix2 C-a
+set -g prefix2 C-b
 bind-key ` send-prefix
 bind-key a send-prefix
 
@@ -47,9 +47,3 @@ set -g status-bg black
 set -g status-fg white
 set-window-option -g window-status-format '#[fg=cyan,dim]#I#[fg=blue]:#[default]#W#[fg=grey,dim]#F'
 set-window-option -g window-status-current-format '#[bg=blue,fg=cyan,bold]#I#[bg=blue,fg=cyan]:#[fg=colour230]#W#[fg=dim]#F'
-
-
-
-
-
-


### PR DESCRIPTION
From the comment, it appeared as if the intention of prefix2 was to keep default tmux functionality for users who did not want to use ```.  However, the default prefix is C-b as determined from the [tmux man page](https://man7.org/linux/man-pages/man1/tmux.1.html)
   
> tmux may be controlled from an attached client by using a key
     combination of a prefix key, ‘C-b’ (Ctrl-b) by default, followed by
     a command key
   
Therefore, C-a was changed to C-b and the comment updated to reflect
 this change.
   
Additionally, whitespace at the end of the files was removed.